### PR TITLE
Make fully automatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ADE_2.0_Installer.exe
 pycrypto-2.6.1.win32-py2.7.exe
 adobekey.py
+wine-mono-7.0.0-x86.msi

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN dpkg --add-architecture i386 && apt-get update && apt-get install -y \
     x11vnc \
     xvfb \
     procps \
+    p7zip-full \
  && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --home /app --create-home app

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ file and defaults to the current directory.
 Known Issues
 ------------
 
-This was developed on Arch Linux and it turned out later it doesn't run on
+* This was developed on Arch Linux and it turned out later it doesn't run on
 Debian 10. It works on Debian 11. My best guess is that it
 doesn't work with older kernels.
+* This does not seem to work with ebooks from archive.org, gives error `E_ADEPT_DOCUMENT_TOO_SHORT`. May be possible to fix by using a newer version of .NET (see https://gist.github.com/bmaupin/65ef52ad8ecec81c6ab897f2224dfa38), haven't tried this.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Adobe Digital Editions Dockerized
 Runs Adobe Digital Editions 2.0.1 in a Docker container using Wine and automates
 the downloading of e-books from ACSM files.
 
-Authorizing Adobe IDs
----------------------
+Generating new IDs
+------------------
 
 One or more Adobe IDs may be authorized. There will be a Docker image for each
 Adobe ID holding the authorized installation of Adobe Digital Editions. When
@@ -15,12 +15,21 @@ One might for example use the name of the person the Adobe ID belongs to.
     ./newid alice
 
 This will run a Docker container and install a fresh instance of Adobe Digital
-Editions inside. Open a VNC client of your choice
-([TigerVNC](https://tigervnc.org/) works) and connect to `localhost:5900`.
+Editions inside. By default, the script generates a machine key automatically.
+If this is not suitable (you want to use an Adobe ID), run `newid` with the
+parameter `--manual-id` to skip this:
+
+    ./newid alice --manual-id
+
+Authorizing Adobe IDs
+---------------------
+
+To complete the authentication, open a VNC client of your choice
+([TigerVNC](https://tigervnc.org/) works. If you are on a server, try
+[noVNC](https://github.com/novnc/noVNC)) and connect to `localhost:5900`.
 When the script runs for the first time the Dockerfile is built before the VNC
 server starts. Be patient and retry connecting. Once you're connected you will
-likely be seeing a blackscreen. Wait for the Adobe Digital Editions installer to
-pop up and advance the installation. This should open up the application.
+likely be seeing a blackscreen.
 Authorize your Adobe ID under *Help -> Authorize Computer* then exit via
 *File -> Exit* which will stop the container. This creates the Docker image
 `adobe_diged_docker:alice` holding the authorized instance of Adobe Digital

--- a/container/install.sh
+++ b/container/install.sh
@@ -10,7 +10,10 @@ msiexec /i wine-mono-7.0.0-x86.msi
 winetricks -q python27
 winetricks -q autohotkey
 
-wine pycrypto-2.6.1.win32-py2.7.exe
+7z x pycrypto-2.6.1.win32-py2.7.exe PLATLIB/Crypto
+mv PLATLIB/Crypto ".wine/drive_c/Python27/Lib/site-packages"
+rmdir PLATLIB
+
 7z x -aos -o".wine/drive_c/Program Files/Adobe/Adobe Digital Editions 2.0/" ADE_2.0_Installer.exe
 mkdir -p "My Digital Editions"
 

--- a/container/install.sh
+++ b/container/install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
 export DISPLAY=:0
 Xvfb :0 -screen 0 1024x768x24 &
 x11vnc -forever &

--- a/container/install.sh
+++ b/container/install.sh
@@ -8,11 +8,15 @@ winetricks -q corefonts
 winetricks -q windowscodecs
 msiexec /i wine-mono-7.0.0-x86.msi
 winetricks -q python27
+winetricks -q autohotkey
 
 wine pycrypto-2.6.1.win32-py2.7.exe
 7z x -aos -o".wine/drive_c/Program Files/Adobe/Adobe Digital Editions 2.0/" ADE_2.0_Installer.exe
 mkdir -p "My Digital Editions"
 
+if [ "${1:-}" != "--manual-id" ]; then
+    wine ".wine/drive_c/Program Files/AutoHotkey/AutoHotkey.exe" "machine.ahk" &
+fi
 wine ".wine/drive_c/Program Files/Adobe/Adobe Digital Editions 2.0/DigitalEditions.exe"
 
 wineserver --kill

--- a/container/install.sh
+++ b/container/install.sh
@@ -6,7 +6,7 @@ export WINEARCH=win32
 
 winetricks -q corefonts
 winetricks -q windowscodecs
-winetricks -q dotnet35sp1
+msiexec /i wine-mono-7.0.0-x86.msi
 winetricks -q python27
 
 wine pycrypto-2.6.1.win32-py2.7.exe

--- a/container/install.sh
+++ b/container/install.sh
@@ -10,7 +10,9 @@ msiexec /i wine-mono-7.0.0-x86.msi
 winetricks -q python27
 
 wine pycrypto-2.6.1.win32-py2.7.exe
-wine ADE_2.0_Installer.exe
+7z x -aos -o".wine/drive_c/Program Files/Adobe/Adobe Digital Editions 2.0/" ADE_2.0_Installer.exe
+mkdir -p "My Digital Editions"
 
-while pgrep DigitalEditions >/dev/null; do sleep 1; done
+wine ".wine/drive_c/Program Files/Adobe/Adobe Digital Editions 2.0/DigitalEditions.exe"
+
 wineserver --kill

--- a/container/machine.ahk
+++ b/container/machine.ahk
@@ -1,0 +1,27 @@
+WinWait, Adobe Digital Editions
+; extremely unreliable, sleeping 1000ms fails often
+Sleep, 10000 ; wait to render
+Send, ^+U ; open auth dialog
+Sleep, 10000 ; wait to render
+Send, {Tab} ; go from email to password
+Sleep, 10000
+Send, {Tab} ; go from password to create
+Sleep, 10000
+Send, {Tab} ; go from create to forgot
+Sleep, 10000
+Send, {Tab} ; go from forgot to checkbox
+Sleep, 10000
+Send, {Space} ; set checkbox
+Sleep, 10000
+Send, {Tab} ; go from checkbox to no
+Sleep, 10000
+Send, {Tab} ; go from no to yes
+Sleep, 10000
+Send, {Enter} ; authorize
+Sleep, 10000
+Send, {Enter} ; confirm local authorize
+Sleep, 10000 ; wait for OK/fail
+; take screenshot here
+Send, {Enter} ; close information box
+Sleep, 10000
+Send, ^q ; close ADE

--- a/newid
+++ b/newid
@@ -30,6 +30,6 @@ wget -P container --no-clobber \
 
 docker build --tag adobe_diged_docker .
 container=$(uuidgen)
-docker run -p 127.0.0.1:5900:5900 --name $container adobe_diged_docker sh install.sh $INSARGS
+docker run -p 127.0.0.1:5900:5900 --name $container adobe_diged_docker bash install.sh $INSARGS
 docker commit $container "adobe_diged_docker:$1" >/dev/null
 docker rm $container >/dev/null

--- a/newid
+++ b/newid
@@ -23,7 +23,7 @@ fi
 
 wget -P container --no-clobber \
     http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.exe \
-    http://www.voidspace.org.uk/python/pycrypto-2.6.1/pycrypto-2.6.1.win32-py2.7.exe \
+    https://web.archive.org/web/20190603051225im_/http://www.voidspace.org.uk/python/pycrypto-2.6.1/pycrypto-2.6.1.win32-py2.7.exe \
     https://raw.githubusercontent.com/apprenticeharper/DeDRM_tools/Python2/DeDRM_plugin/adobekey.py \
     https://dl.winehq.org/wine/wine-mono/7.0.0/wine-mono-7.0.0-x86.msi \
  || exit 1

--- a/newid
+++ b/newid
@@ -1,8 +1,19 @@
 #!/bin/sh
 
-if [ "$#" -ne 1 ]; then
-    echo "usage: newid <tag>"
+if [ "$#" -ne 1 ] && [ "$#" -ne 2 ]; then
+    echo "usage: newid <tag> [--manual-id]"
     exit 1
+fi
+
+INSARGS=""
+
+if [ "$#" -eq 2 ]; then
+    if [ "$2" = '--manual-id' ]; then
+        INSARGS='--manual-id'
+    else
+        echo "unknown argument $2"
+        exit 1
+    fi
 fi
 
 if ! (echo "$1" | grep -Eq  ^[a-zA-Z0-9_][a-zA-Z0-9_.-]*$) || [ "$1" = "latest" ]; then
@@ -19,6 +30,6 @@ wget -P container --no-clobber \
 
 docker build --tag adobe_diged_docker .
 container=$(uuidgen)
-docker run -p 127.0.0.1:5900:5900 --name $container adobe_diged_docker sh install.sh
+docker run -p 127.0.0.1:5900:5900 --name $container adobe_diged_docker sh install.sh $INSARGS
 docker commit $container "adobe_diged_docker:$1" >/dev/null
 docker rm $container >/dev/null

--- a/newid
+++ b/newid
@@ -14,6 +14,7 @@ wget -P container --no-clobber \
     http://download.adobe.com/pub/adobe/digitaleditions/ADE_2.0_Installer.exe \
     http://www.voidspace.org.uk/python/pycrypto-2.6.1/pycrypto-2.6.1.win32-py2.7.exe \
     https://raw.githubusercontent.com/apprenticeharper/DeDRM_tools/Python2/DeDRM_plugin/adobekey.py \
+    https://dl.winehq.org/wine/wine-mono/7.0.0/wine-mono-7.0.0-x86.msi \
  || exit 1
 
 docker build --tag adobe_diged_docker .


### PR DESCRIPTION
These changes make all applications involved install fully unattended. The documentation is altered to inform of this. Furthermore, .NET is switched to mono because of its lower complexity, logs are made more descriptive, and the readme is updated.